### PR TITLE
Update v2 db setup instructions to use local config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ make wipe_db
 To build out the data you'll need to jump into the Django shell
 
 ```
-$ python manage.py shell
+$ python manage.py shell --settings=config.local
 ```
 and run the build script with
 ```


### PR DESCRIPTION
Trying to set up a local instance, I ran into some minor trouble trying to import the v2 since the README's command to open a python shell wasn't passing in the settings config file flag, resulting in the v2 db import script trying to hit a postgres instance instead of the sqlite file.

This just adds that flag to the README.