### PR TITLE
Fixing Issue #85 (Duplicated Move Data)

### DIFF
--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -2272,8 +2272,10 @@ class PokemonDetailSerializer(serializers.ModelSerializer):
         method_objects = MoveLearnMethod.objects.all()
         method_data = MoveLearnMethodSummarySerializer(method_objects, many=True, context=self.context).data
 
-        # Get moves related to this pokemon and pull out unique Move IDs
-        pokemon_moves = PokemonMove.objects.filter(pokemon_id=obj).order_by('level')
+        # Get moves related to this pokemon and pull out unique Move IDs.  Note that it's important to order
+        # by the same column we're using to determine if the entries are unique.  Otherwise distinct() will
+        # return apparent duplicates.
+        pokemon_moves = PokemonMove.objects.filter(pokemon_id=obj).order_by('move_id')
         move_ids = pokemon_moves.values('move_id').distinct()
         move_list = []
 


### PR DESCRIPTION
Contains a fix and testing for the following issue:

I found that we are sometimes sending multiple exact duplicates of
pokemon move data when there are different levels at which a pokemon
learns a move for different version groups.  I found that the problem
was that we were using order_by('level') and duplicate('move_id') .
This link explains why this behavior happens.
https://docs.djangoproject.com/en/1.7/ref/models/querysets/#distinct