### PR TITLE
Optimize data loading time by 76%

### DIFF
--- a/data/v2/build.py
+++ b/data/v2/build.py
@@ -23,6 +23,8 @@ import re
 import json
 from django.db import connection
 from pokemon_v2.models import *  # NOQA
+from django.db.models import get_app, get_models
+from django.core import serializers
 
 
 # why this way? how about use `__file__`
@@ -2471,6 +2473,15 @@ def build_all():
     build_pokemons()
     build_encounters()
     build_pal_parks()
+
+def dump_all():
+    app = get_app('pokemon_v2')
+    for model in get_models(app):
+        data = serializers.serialize("json", model.objects.all())
+        file_name = os.getcwd() + "/pokemon_v2/fixtures/" + str(model).split("'")[1].split(".")[2] + ".json"
+        out = open(file_name, "w")
+        out.write(data)
+        out.close()
 
 if __name__ == '__main__':
     build_all()


### PR DESCRIPTION
Still learning this process but hopefully this might help in development....

Here's how the improvement works:

1. Build project as is with build_all(); //took me 26m 7362s
2. Once all data is loaded, run dump_all(); //took me 49.7914s
3. Anytime afterwards, if 'make wipe_db' is executed, after 'make setup' the following command will build the entire database 76% faster:

python manage.py loaddata pokemon_v2/fixtures/*.json --settings=config.local

//took me 6m 4141s