### PR TITLE
Use empty list instead of null for evolution details

### DIFF
--- a/pokemon_v2/serializers.py
+++ b/pokemon_v2/serializers.py
@@ -2872,7 +2872,7 @@ class EvolutionChainDetailSerializer(serializers.ModelSerializer):
 
             entry['is_baby'] = species['is_baby']
             entry['species'] = summary_data[index]
-            entry['evolution_details'] = evolution_data or None
+            entry['evolution_details'] = evolution_data or []
             entry['evolves_to'] = []
 
             # Keep track of previous entries for complex chaining


### PR DESCRIPTION
Minor fix related to my earlier PR #190, empty list should be returned instead of null.